### PR TITLE
Fix typo and remove defunct db url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 app/.DS_Store
 .DS_Store
 config/settings.js
+**/lib/

--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,6 @@
   ],
   "dependencies": {
     "angular": "~1.3.13",
-    "angular-route": "~1.3.14",
+    "angular-route": "~1.3.14"
   }
 }

--- a/config/settings.js
+++ b/config/settings.js
@@ -1,3 +1,3 @@
 module.exports = {
-    'url' : 'mongodb://andy:andy@ds029814.mlab.com:29814/web-demo'
+    'url' : 'super secret db key'
 };


### PR DESCRIPTION
Fixed a type in the bower.json file and removed the url for the mongodb instance I set up for the demo. That instance has been deleted so it's useless at this point.